### PR TITLE
Bumped react to 19.2.3 to patch CVE-2025-67779

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@tinacms/auth": "^1.1.0",
     "@tinacms/cli": "^2.0.1",
     "next-tinacms-cloudinary": "^17.0.1",
-    "react": "^19.2.1",
-    "react-dom": "^19.2.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "tinacms": "^3.0.1"
   }
 }


### PR DESCRIPTION
This PR bumps the version of `react` and `react-dom` to 19.2.3 to patch [CVE-2025-67779](https://www.cve.org/CVERecord?id=CVE-2025-67779)