### PR TITLE
chore: bump @tinacms/cli to 2.3.1, fix broken build-local script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tinacms dev -c \"hugo server -D\"",
     "build": "tinacms build && hugo",
-    "build-local": "tinacms build --local --skip-indexing --skip-cloud-checks && hugo",
+    "build-local": "tinacms build --content=local --skip-cloud-checks -c \"hugo\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -25,10 +25,10 @@
   },
   "dependencies": {
     "@tinacms/auth": "^1.1.0",
-    "@tinacms/cli": "^2.0.1",
+    "@tinacms/cli": "^2.3.1",
     "next-tinacms-cloudinary": "^17.0.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "tinacms": "^3.0.1"
+    "tinacms": "^3.8.1"
   }
 }


### PR DESCRIPTION
## Summary

Two small linked changes:

1. **Bumps `@tinacms/cli` `^2.0.1` → `^2.3.1` and `tinacms` `^3.0.1` → `^3.8.1`** to pick up the `--content=local` flag added in [tinacms/tinacms#6636](https://github.com/tinacms/tinacms/pull/6636). These were both several minors behind.
2. **Rewrites the `build-local` script:**

   ```diff
   - "build-local": "tinacms build --local --skip-indexing --skip-cloud-checks && hugo",
   + "build-local": "tinacms build --content=local --skip-cloud-checks -c \"hugo\"",
   ```

## Why the old `build-local` produced broken artifacts

Hugo itself doesn't crash on the old script (Hugo reads markdown directly and doesn't query GraphQL at build time), so the build *appears* to succeed. But:

- `--local` makes `tinacms build` emit a generated client pointing at `http://localhost:4001`. That URL is baked into the static admin bundle and the generated `client.ts`.
- Anyone who deploys the resulting `public/` directory ships an admin UI / client that tries to talk to `localhost:4001` at runtime — broken everywhere except the dev's machine.

`--content=local` solves this: indexes content from the filesystem during the build (no Tina Cloud network calls, no real creds needed), but generates a production-shaped client that points at TinaCloud — so the artifact is deployable as-is.

## Verification

```
TINA_CLIENT_ID=fake-id-for-smoke \
TINA_TOKEN=fake-token-for-smoke \
TINA_BRANCH=main \
pnpm run build-local
```

Result: **✓ 11 pages built clean** (hugo v0.161.1), zero Tina Cloud network calls.

## Notes

- This repo doesn't ship a lockfile, so the version bump only requires the `package.json` change.
- The dep diff also includes the `@tinacms/auth` and `next-tinacms-cloudinary` peers — those weren't touched, only `@tinacms/cli` and `tinacms` were bumped.

## Test plan

- [ ] CI: `npm install` / `pnpm install` resolves to `@tinacms/cli@2.3.1` and `tinacms@3.8.1`
- [ ] `pnpm run build` still works with real Tina Cloud creds (unchanged script)
- [ ] `pnpm run build-local` works with dummy/no creds (the case this PR fixes)
- [ ] `pnpm run dev` still works (unchanged script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)