### PR TITLE
fix(deps): bump next-tinacms-cloudinary 17.0.1 → 25.0.1 to match tinacms 3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@tinacms/auth": "^1.1.0",
     "@tinacms/cli": "^2.3.1",
-    "next-tinacms-cloudinary": "^17.0.1",
+    "next-tinacms-cloudinary": "^25.0.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "tinacms": "^3.8.1"


### PR DESCRIPTION
## Summary

Fixes the npm peer-dep resolution failure in nightly [`build-starter-templates`](https://github.com/tinacms/tinacms/actions/runs/26395938910/) for `npm × Node 22/24/25 × tina-hugo-starter`. Introduced by #56 (which bumped `tinacms` to `^3.8.1` without also bumping `next-tinacms-cloudinary`).

```diff
- "next-tinacms-cloudinary": "^17.0.1",
+ "next-tinacms-cloudinary": "^25.0.1",
```

## Root cause

`next-tinacms-cloudinary` declares a strict peer-dep on a specific `tinacms` patch version per major release:

| `next-tinacms-cloudinary` | `tinacms` peer |
| --- | --- |
| `17.x` | `3.0.x` |
| `18.x` | `3.1.x` |
| `19.x` | `3.2.x` |
| `20.x` | `3.3.x` |
| `21.x` | `3.4.x` |
| `22.x` | `3.5.x` |
| `23.x` | `3.6.x` |
| `24.x` | `3.7.x` |
| **`25.x`** | **`3.8.x`** ← needed for `tinacms@^3.8.1` |

Latest `17.0.2` insists on `tinacms@3.0.2` exactly. npm 7+ enforces peer-deps strictly, hence the `ERESOLVE` failure:

```
npm error Found: tinacms@3.8.1
npm error Could not resolve dependency:
npm error peer tinacms@"3.0.2" from next-tinacms-cloudinary@17.0.2
```

pnpm and yarn auto-install-peers and are more lenient about peer-dep mismatches — that's why the other 11 nightly jobs (pnpm + yarn × 3 Node versions × `tina-hugo-starter`) passed. My pre-merge smoke test for #56 was pnpm-only, which is why this wasn't caught.

## Verification

```
$ npm install
added 1129 packages, and audited 1130 packages in 23s
$ npm ls tinacms next-tinacms-cloudinary
tina-hugo-starter@1.0.0
+-- next-tinacms-cloudinary@25.0.1
+-- @tinacms/cli@2.3.1
|   `-- tinacms@3.8.1 deduped
`-- tinacms@3.8.1

$ TINA_CLIENT_ID=fake-id-for-smoke TINA_TOKEN=fake-token-for-smoke TINA_BRANCH=main npm run build-local
✓ 11 pages (hugo v0.161.1)
```

## Test plan

- [ ] CI: nightly `build-starter-templates` next Monday — `npm × tina-hugo-starter × Node 22/24/25` jobs pass
- [ ] Doesn't regress pnpm / yarn matrix entries
- [ ] `npm run build-local` (manual local check) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)