### PR TITLE
fix(gitignore): stop ignoring tina/tina-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@ node_modules
 .env
 public
 
-*-lock.*
+# Package Manager Lock Files (templates only — remove if your project uses one)
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+bun.lockb
+deno.lock


### PR DESCRIPTION
## Why

The `*-lock.*` glob at the root of `.gitignore` was inadvertently catching `tina/tina-lock.json` — the glob matches by basename at any depth, so `tina/tina-lock.json` falls under it the same way `package-lock.json` does.

TinaCloud's webhook handler relies on changes to `tina/tina-lock.json` to detect schema updates. When the file is gitignored, schema changes are silently never indexed — the dashboard shows a stale schema indefinitely, new collections appear to do nothing, and the user gets no error.

This was found via a real production support ticket — see [tinacms/tinacloud#3614](https://github.com/tinacms/tinacloud/issues/3614) for the full investigation and [tinacms/tinacms#6972](https://github.com/tinacms/tinacms/issues/6972) for the cross-starter audit.

## What changed

Replaced the broad `*-lock.*` glob with explicit package-manager lock filenames (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, `deno.lock`), matching the convention already used by [`tina-astro-starter`](https://github.com/tinacms/tina-astro-starter/blob/main/.gitignore). `tina/tina-lock.json` is now tracked, which is what TinaCloud expects.

## Test plan

- [ ] `git check-ignore -v tina/tina-lock.json` should return nothing (file is not ignored) on a fresh clone of this branch
- [ ] `git check-ignore -v package-lock.json` should still match the new explicit rule
- [ ] Spin up a TinaCloud project from this starter, add a new collection to `tina/config.ts`, run `tinacms build`, commit, push — confirm the new collection appears in the dashboard
