### PR TITLE
⬆️ Update TinaCMS packages to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@tinacms/auth": "^1.1.0",
-    "@tinacms/cli": "^2.3.1",
-    "next-tinacms-cloudinary": "^25.0.1",
+    "@tinacms/auth": "^1.1.3",
+    "@tinacms/cli": "^2.5.3",
+    "next-tinacms-cloudinary": "^27.0.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "tinacms": "^3.8.1"
+    "tinacms": "^3.10.0"
   }
 }


### PR DESCRIPTION
## TL;DR

Bumps the Tina packages to the versions released today: tinacms 3.8.1 → 3.10.0, @tinacms/cli 2.3.1 → 2.5.3, @tinacms/auth 1.1.0 → 1.1.3, next-tinacms-cloudinary 25.0.1 → 27.0.0. Verified locally with `tinacms build --content=local --skip-cloud-checks` on the new versions; schema, generated client, and admin all build clean.

Part of the org-wide rollout of today's tinacms@3.10.0 release.